### PR TITLE
pluralize "Data Structures" category in cabal file

### DIFF
--- a/trie-simple.cabal
+++ b/trie-simple.cabal
@@ -14,7 +14,7 @@ license-file:        LICENSE
 author:              Koji Miyazato
 maintainer:          viercc@gmail.com
 copyright:           Koji Miyazato
-category:            Data Structure
+category:            Data Structures
 build-type:          Simple
 extra-source-files:  README.md, CHANGELOG.md
 cabal-version:       2.0


### PR DESCRIPTION
Hi, sorry for the small annoying change - I was just noticing that there are two very similar categories on Hackage, ["Data Structure"](https://hackage.haskell.org/packages/#cat:Data%20Structure) and "Data Structures", and the latter is much more widely used. I thought it would be nicer for people perusing the packages if we could get the categories more standardized.