### PR TITLE
Relax containers, deepseq bounds

### DIFF
--- a/trie-simple.cabal
+++ b/trie-simple.cabal
@@ -34,8 +34,8 @@ library
   other-modules:       Data.Trie.Set.Hidden,
                        Data.Trie.Map.Hidden
   build-depends:       base         >= 4.14     && < 4.20,
-                       containers   >= 0.5.7.1 && < 0.7,
-                       deepseq      >= 1.4.2.0 && < 1.5,
+                       containers   >= 0.5.7.1 && < 0.8,
+                       deepseq      >= 1.4.2.0 && < 1.6,
                        mtl          >= 2.2.1   && < 2.4,
                        indexed-traversable >= 0.1.1 && <0.2,
                        witherable   ^>= 0.4,


### PR DESCRIPTION
This is required for GHC-9.8.1 compatibility. See: https://github.com/commercialhaskell/stackage/issues/7217.

I've checked that it builds and that the test suite runs successfully.