### PR TITLE
Relax hashable bound

### DIFF
--- a/trie-simple.cabal
+++ b/trie-simple.cabal
@@ -40,7 +40,7 @@ library
                        indexed-traversable >= 0.1.1 && <0.2,
                        witherable   >= 0.4 && < 0.6,
                        matchable    ^>= 0.1.2,
-                       hashable     >= 1.3 && < 1.5,
+                       hashable     >= 1.3 && < 1.6,
                        semialign    >= 1.3 && < 1.4,
                        these        >= 1 && < 2
   default-language:    Haskell2010


### PR DESCRIPTION
I've run the test suite with the new hashable version and it passes.

Could you please make a Hackage revision when you get a chance?

See: https://github.com/commercialhaskell/stackage/issues/7476